### PR TITLE
[codex] Add CI and harden local config loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit
+        run: npm audit --audit-level=high
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test -- --watch=false --browsers=ChromeHeadless
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: npm run e2e

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ node_modules/
 .env
 .env.*
 /src/assets/config.local.js
+/src/assets/config.local.json
 
 # Generated docs folder
 docs/

--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -16,12 +16,12 @@ La app carga Google Maps de forma dinamica desde `GoogleMapsService`. No hay cla
 
 ### Desarrollo local
 
-Para probar mapas en local, configura `src/assets/config.js` en tu copia local:
+Para probar mapas en local, crea `src/assets/config.local.json`:
 
-```js
-window.__KAMAK_CONFIG__ = {
-  googleMapsApiKey: 'tu_clave_restringida'
-};
+```json
+{
+  "googleMapsApiKey": "tu_clave_restringida"
+}
 ```
 
 No subas una clave real al repositorio.

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ npm run e2e:ui
 
 Google Maps is loaded dynamically. Do not commit real API keys.
 
-For local development, edit `src/assets/config.js` locally or inject this before loading the app:
+For local development, create `src/assets/config.local.json`:
 
-```js
-window.__KAMAK_CONFIG__ = {
-  googleMapsApiKey: 'your-restricted-browser-key'
-};
+```json
+{
+  "googleMapsApiKey": "your-restricted-browser-key"
+}
 ```
 
 For GitHub Pages, set the repository secret `GOOGLE_MAPS_API_KEY`; the deploy workflow writes `src/assets/config.js` during the build.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,14 +28,12 @@ export default defineConfig({
       name: 'desktop-chrome',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome',
       },
     },
     {
       name: 'mobile-chrome',
       use: {
         ...devices['Pixel 5'],
-        channel: 'chrome',
       },
     },
   ],

--- a/src/app/core/services/google-maps.service.ts
+++ b/src/app/core/services/google-maps.service.ts
@@ -36,7 +36,7 @@ export class GoogleMapsService {
 
       const script = document.createElement('script');
       script.type = 'text/javascript';
-      script.src = `https://maps.googleapis.com/maps/api/js?key=${this.apiKey}&libraries=places`;
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${this.apiKey}&libraries=places&loading=async`;
       script.async = true;
       script.defer = true;
 

--- a/src/assets/config.js
+++ b/src/assets/config.js
@@ -1,3 +1,21 @@
 window.__KAMAK_CONFIG__ = window.__KAMAK_CONFIG__ || {
   googleMapsApiKey: ''
 };
+
+if (['localhost', '127.0.0.1'].includes(window.location.hostname)) {
+  try {
+    var request = new XMLHttpRequest();
+    request.open('GET', 'assets/config.local.json', false);
+    request.send(null);
+
+    if (request.status === 200) {
+      window.__KAMAK_CONFIG__ = Object.assign(
+        {},
+        window.__KAMAK_CONFIG__,
+        JSON.parse(request.responseText)
+      );
+    }
+  } catch (error) {
+    console.warn('Local config could not be loaded.', error);
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
 
     <base href="/" />
     <script src="assets/config.js"></script>
-    <script src="assets/config.local.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link rel="icon" type="image/svg+xml" href="/assets/logos/favicon.svg" />
     <link


### PR DESCRIPTION
﻿## What changed

- Added a CI workflow that runs npm audit, production build, unit tests, installs Playwright Chromium, and runs e2e tests.
- Made Playwright use bundled Chromium instead of depending on a locally installed Chrome channel.
- Changed local Maps config to use ignored `src/assets/config.local.json` loaded by `config.js` only on localhost/127.0.0.1.
- Removed the committed `config.local.js` script include path from `index.html` to avoid production 404s.
- Added `loading=async` to the Google Maps JS API script URL.

## Validation

- `npm.cmd run build`
- `npm.cmd test -- --watch=false --browsers=ChromeHeadless` => 9 SUCCESS
- `npm.cmd audit --audit-level=high` => 0 vulnerabilities
- `npm.cmd run e2e` => 6 passed
